### PR TITLE
Fix deepseek.py errors: switch to local HuggingFace embeddings, update deprecated methods

### DIFF
--- a/deepseek.py
+++ b/deepseek.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import getpass
+from langchain_community.document_loaders import DirectoryLoader
+from langchain.indexes import VectorstoreIndexCreator
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain.chat_models import init_chat_model
+from langchain.chains import RetrievalQA
+from langchain_community.vectorstores import Chroma
+
+if not os.environ.get("DEEPSEEK_API_KEY"):
+    os.environ["DEEPSEEK_API_KEY"] = getpass.getpass("Enter API key for DeepSeek: ")
+
+llm = init_chat_model("deepseek-chat", model_provider="deepseek")
+
+query = sys.argv[1]
+
+loader = DirectoryLoader(".", glob="*.txt")
+embedding = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+index = VectorstoreIndexCreator(vectorstore_cls=Chroma, embedding=embedding).from_loaders([loader])
+
+qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=index.vectorstore.as_retriever())
+
+print(qa.invoke({"query": query}))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+langchain
+langchain-deepseek
+openai
+langchain-community
+langchain-openai
+chromadb
+langchain-huggingface


### PR DESCRIPTION
This PR fixes the issues in deepseek.py by switching to local HuggingFace embeddings to avoid OpenAI rate limits, updating deprecated method calls to use invoke instead of run, and cleaning up unnecessary imports. It also updates requirements.txt accordingly.